### PR TITLE
docs: add important warning for using `defaultPopulate` on collections with an upload field.

### DIFF
--- a/docs/queries/select.mdx
+++ b/docs/queries/select.mdx
@@ -137,6 +137,11 @@ export const Pages: CollectionConfig<'pages'> = {
 }
 ```
 
+<Banner type="warning">
+  <strong>Important:</strong>
+  When using `defaultPopulate` on collections with a [Upload](/docs/fields/upload) field, it is important to specify `filename: true` and `url: true`, otherwise Payload will not be able to fetch the correct image URL and populate the URL field in your queries, instead returning `url: null`.
+</Banner>
+
 ## populate
 
 Setting `defaultPopulate` will enforce that each time Payload performs a "population" of a related document, only the fields specified will be queried and returned. However, you can override `defaultPopulate` with the `populate` property in the Local and REST API:


### PR DESCRIPTION
Adding a warning for using `defaultPopulate` field on collections with an upload field. This is an important note as without specifying both `filename: true` and `url: true` Payload APIs will return `url: null` for uploads.

<!--

Thank you for the PR! Please go through the checklist below and make sure you've completed all the steps.

Please review the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository if you haven't already.

The following items will ensure that your PR is handled as smoothly as possible:

- PR Title must follow conventional commits format. For example, `feat: my new feature`, `fix(plugin-seo): my fix`.
- Minimal description explained as if explained to someone not immediately familiar with the code.
- Provide before/after screenshots or code diffs if applicable.
- Link any related issues/discussions from GitHub or Discord.
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

### Why?

### How?

Fixes #

-->
